### PR TITLE
:fire: support 8-digit-hex-color-codes for adding support of alpha va…

### DIFF
--- a/src/hexColorCode.js
+++ b/src/hexColorCode.js
@@ -3,7 +3,7 @@ import Joi from "joi"
 
 const validate = value => {
   Joi.assert(value, Joi.string(), new TypeError(`Value is not string: ${value}`))
-  Joi.assert(value, Joi.string().regex(/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/), new TypeError(`Value is not a valid HexColorCode: ${value}`))
+  Joi.assert(value, Joi.string().regex(/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3}|[A-Fa-f0-9]{8})$/), new TypeError(`Value is not a valid HexColorCode: ${value}`))
   return value
 }
 


### PR DESCRIPTION
In order to Support Alpha values (transparency) for 'HexColorCodes' there is a support for 8 digit hexColorCode needed. See this source:  https://stackoverflow.com/questions/15852122/hex-transparency-in-colors